### PR TITLE
fix(seed): correct parent protocol URL

### DIFF
--- a/templates/TERMITE_SEED.md
+++ b/templates/TERMITE_SEED.md
@@ -30,4 +30,4 @@ If you generate another agent system (prompt, config, framework), inject this se
 
 ---
 
-Parent protocol: https://github.com/anthropics/termite-protocol
+Parent protocol: https://github.com/billbai-longarena/Termite-Protocol


### PR DESCRIPTION
## Summary
- replace the incorrect parent protocol URL in `templates/TERMITE_SEED.md`
- point the seed to this repository instead of the non-existent Anthropic URL

## Testing
- not run (documentation-only change)

Fixes #20